### PR TITLE
Capture tqdm logs by redirecting stderr within context manager

### DIFF
--- a/elpis/trainer/utils.py
+++ b/elpis/trainer/utils.py
@@ -1,10 +1,11 @@
 import logging
+import sys
 from contextlib import contextmanager
 from logging.handlers import WatchedFileHandler
 from pathlib import Path
 
-import transformers
 from loguru import logger
+from transformers.utils import logging as transformer_logging
 
 
 @contextmanager
@@ -23,13 +24,19 @@ def log_to_file(log_file: Path):
     logging.root.addHandler(handler)
 
     # Propagate huggingface logs to logging root.
-    transformers.logging.set_verbosity_info()
-    transformers.logging.enable_propagation()
+    transformer_logging.set_verbosity_info()
+    transformer_logging.enable_propagation()
+    transformer_logging.disable_default_handler()
 
-    try:
-        yield log_file
-    finally:
-        # Flush and teardown logging handlers
-        logger.remove(sink_id)
-        handler.flush()
-        logging.root.removeHandler(handler)
+    # Log stderr to log file to capture tqdm logs
+    with open(log_file, 'a') as stderr_hole:
+        original_stderr = sys.stderr
+        try:
+            sys.stderr = stderr_hole 
+            yield log_file
+        finally:
+            sys.stderr = original_stderr
+            # Flush and teardown logging handlers
+            logger.remove(sink_id)
+            handler.flush()
+            logging.root.removeHandler(handler)

--- a/elpis/trainer/utils.py
+++ b/elpis/trainer/utils.py
@@ -29,10 +29,10 @@ def log_to_file(log_file: Path):
     transformer_logging.disable_default_handler()
 
     # Log stderr to log file to capture tqdm logs
-    with open(log_file, 'a') as stderr_hole:
+    with open(log_file, "a") as stderr_hole:
         original_stderr = sys.stderr
         try:
-            sys.stderr = stderr_hole 
+            sys.stderr = stderr_hole
             yield log_file
         finally:
             sys.stderr = original_stderr

--- a/tests/trainer/test_utils.py
+++ b/tests/trainer/test_utils.py
@@ -1,6 +1,8 @@
+import sys
 from pathlib import Path
 
 from loguru import logger
+from transformers.utils import logging
 
 from elpis.trainer.utils import log_to_file
 
@@ -11,6 +13,32 @@ def test_log_to_file_captures_loguru_logs(tmp_path: Path):
     with log_to_file(log_file):
         logger.info("TEST")
 
-    assert log_file.exists()
+    assert log_file.exists(), "Couldn't find log file"
     with open(log_file) as _logs:
         assert "TEST" in _logs.read()
+
+
+def test_log_to_file_captures_hugging_face_logs(tmp_path: Path):
+    log_file = tmp_path / "logs.txt"
+
+    with log_to_file(log_file):
+        logger = logging.get_logger("transformers")
+        logger.info("TEST")
+
+    assert log_file.exists(), "Couldn't find log file"
+    with open(log_file) as _logs:
+        assert "TEST" in _logs.read()
+
+
+def test_log_to_file_captures_hugging_face_tqdm_logs(tmp_path: Path):
+    log_file = tmp_path / "logs.txt"
+
+    original_stderr = sys.stderr
+    with log_to_file(log_file):
+        for _ in logging.tqdm(range(3)):
+            pass
+
+    assert original_stderr is sys.stderr, "Original stderr not replaced!"
+    assert log_file.exists(), "Couldn't find log file"
+    with open(log_file) as _logs:
+        assert len(_logs.read()) > 0, "Didn't capture tqdm logs"


### PR DESCRIPTION
- Redirect `stderr` to the logging file provided within the `log_to_file` context manager. 
- Added some tests to check that `stderr` is restored after the context manager ends. 

This means that tqdm logs also get stored in the logging file. The idea here is that when using this in elpis, we're going to be able to see the download progress in the trainer/transcription logging.


